### PR TITLE
feat(netbox): Add Netbox Script to create a Switch

### DIFF
--- a/tools/netbox/scripts/create-switch/create-switch.py
+++ b/tools/netbox/scripts/create-switch/create-switch.py
@@ -69,23 +69,8 @@ class CreateSwitch(Script):
         description="Management VLAN",
         model=VLAN,
         query_params={
+            'group_id': '$vlan_group',
             'vid': [666, 667],
-        }
-    )
-    mgmt_prefix_v4 = ObjectVar(
-        description="IPv4 Prefix to assign a management IP Address from",
-        model=Prefix,
-        query_params={
-            'family': 4,
-            'vlan_id': '$mgmt_vlan'
-        }
-    )
-    mgmt_prefix_v6 = ObjectVar(
-        description="IPv6 Prefix to assign a management IP Address from",
-        model=Prefix,
-        query_params={
-            'family': 6,
-            'vlan_id': '$mgmt_vlan'
         }
     )
     tags = MultiObjectVar(
@@ -159,11 +144,14 @@ class CreateSwitch(Script):
         )
         self.log_success("Created AE and VLAN interfaces for both ends")
 
+        mgmt_prefix_v4 = mgmt_vlan.prefixes.get(prefix__family=4)
+        mgmt_prefix_v6 = mgmt_vlan.prefixes.get(prefix__family=6)
+
         v4_mgmt_addr = IPAddress.objects.create(
-            address=data['mgmt_prefix_v4'].get_first_available_ip(),
+            address=mgmt_prefix_v4.get_first_available_ip(),
         )
         v6_mgmt_addr = IPAddress.objects.create(
-            address=data['mgmt_prefix_v6'].get_first_available_ip(),
+            address=mgmt_prefix_v6.get_first_available_ip(),
         )
         mgmt_vlan_interface.ip_addresses.add(v4_mgmt_addr)
         mgmt_vlan_interface.ip_addresses.add(v6_mgmt_addr)

--- a/tools/netbox/scripts/create-switch/create-switch.py
+++ b/tools/netbox/scripts/create-switch/create-switch.py
@@ -198,8 +198,7 @@ class CreateSwitch(Script):
                 termination_type=interface_type,
             )
             cable = Cable.objects.get(id=cable.id)
-            # TODO: fix cables being 'connected'
-            #cable.a_terminations = [a]
-            #cable.b_terminations = [b]
+            # https://github.com/netbox-community/netbox/discussions/10199
+            cable._terminations_modified = True
             cable.save()
             self.log_success(f"Cabled {data['destination_device']} {a_interface} to {switch} {b_interface}")

--- a/tools/netbox/scripts/create-switch/create-switch.py
+++ b/tools/netbox/scripts/create-switch/create-switch.py
@@ -5,143 +5,351 @@ from dcim.choices import DeviceStatusChoices, InterfaceModeChoices, InterfaceTyp
 from dcim.models import Cable, CableTermination, Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
 from extras.models import Tag
 from extras.scripts import *
-from ipam.models import IPAddress, Prefix, VLAN, VLANGroup
+from ipam.models import IPAddress, Prefix, VLAN, VLANGroup, Role
+from ipam.choices import PrefixStatusChoices, IPAddressFamilyChoices
+import random
+
+from utilities.exceptions import AbortScript
+
+# self.log_success for successfull creation
+# self.log_info for FYI information
+
+# Todo:
+# * Tag switch based on this so config in templates is correct, see tags in tech-templates
+#   * https://github.com/gathering/tech-templates
+# * We should be able to choose a VLAN that actually exists. This will make switch delivery on stand MUCH easier
 
 # Used for getting existing types/objects from Netbox.
 DISTRIBUTION_SWITCH_DEVICE_ROLE = 'distribution-switch' # match the name or the slug
 ROUTER_DEVICE_ROLE = 'router'
 CORE_DEVICE_ROLE = 'core'
 ACCESS_SWITCH_DEVICE_ROLE = DeviceRole.objects.get(name='Access Switch')
-DEFAULT_SITE = Site.objects.first()  # TODO: pick default site ?
+DEFAULT_SITE = Site.objects.get(slug='ring') # Site.objects.first()  # TODO: pick default site ?
+DEFAULT_L1_SWITCH = Device.objects.get(name='d1.ring') # Site.objects.first()  # TODO: pick default site ?
+DEFAULT_DEVICE_TYPE = DeviceType.objects.get(model='EX2200-48T') # Site.objects.first()  # TODO: pick default site ?
+
+UPLINK_TYPES = (
+    (InterfaceTypeChoices.TYPE_10GE_SFP_PLUS, '10G SFP+'),
+    (InterfaceTypeChoices.TYPE_1GE_FIXED, '1G CAT'),
+    (InterfaceTypeChoices.TYPE_10GE_FIXED, '10G CAT')
+)
+
+LEVERANSE_TYPES = (
+    (DeviceRole.objects.get(name='Access Switch'), 'Access Switch'),
+    (DeviceRole.objects.get(name='Distribution Switch'), '"Utskutt" distro')
+)
+
+# Helper functions
+def generateMgmtVlan(self, data):
+        name = ''
+
+        if data['leveranse'].name == "Access Switch":
+            name += "edge-mgmt."
+        elif data['leveranse'].name == "Distribution Switch":
+            name += "distro-mgmt."
+        else:
+            raise AbortScript(f"Tbh, i only support access_switch and distro_switch in role")
+        
+        if "ring" in data['site'].slug or "floor" in data['site'].slug:
+            name += data['site'].slug + ".r1.tele"
+        elif "stand" in data['site'].slug:
+            name += data['site'].slug + ".r1.stand"
+        else:
+            raise AbortScript(f"I only support creating switches in floor, ring or stand")
+
+        return VLAN.objects.get(name=name)
+
+# Cheeky, let's just do this hardcoded...
+def getL3(self, data):
+    if data['site'].slug == "ring":
+
+        l3Term = Device.objects.get(
+            name='r1.tele'
+        )
+        l3Intf = Interface.objects.get(
+            device=l3Term.id,
+            name='ae11'
+        )
+
+    elif data['site'].slug == "stand":
+        l3Term = Device.objects.get(
+            name='r1.stand'
+        )
+        l3Intf = "NOT IMPLEMENTED LOCAL VLAN OPTION. THIS USECAE DOESN'T WORK"
+
+    elif data['site'].slug == "floor":
+        l3Term = Device.objects.get(
+            name='r1.tele'
+        )
+        l3Intf = Interface.objects.get(
+            device=l3Term.id,
+            name='ae10'
+        )
+    else:
+        raise AbortScript(f"I only support creating switches in floor, ring or stand")
+
+    self.log_info(f"l3Term: {l3Term}, l3Intf {l3Intf}")
+    return l3Term, l3Intf
+
+def generatePrefix(prefix, length):
+
+    firstPrefix = prefix.get_first_available_prefix()
+    out = list(firstPrefix.subnet(length, count=1))[0]
+    return out
+
+def getDeviceRole(type):
+    if type == "Access Switch":
+        out = DeviceRole.objects.get(name='Access Switch')
+    elif type == "Distribution Switch":
+        out = DeviceRole.objects.get(name='Distribution Switch')
+    return out
+
 
 class CreateSwitch(Script):
 
     class Meta:
         name = "Create Switch"
         description = "Provision a new switch"
+        commit_default = False
         field_order = ['site_name', 'switch_count', 'switch_model']
+        fieldsets = ""
+
+    leveranse = ChoiceVar(
+        label='Leveranse Type',
+        description="Pick the appropriate leveranse type",
+        choices=LEVERANSE_TYPES,
+        #default=ACCESS_SWITCH_DEVICE_ROLE.id,
+    )
 
     switch_name = StringVar(
-        description="Switch name"
+        description="Switch name. Remember, e = access switch, d = distro switch"
+    )
+
+    uplink_type = ChoiceVar(
+        label='Uplink Type',
+        description="What type of interface should this switch be delivered on",
+        choices=UPLINK_TYPES,
+        default=InterfaceTypeChoices.TYPE_1GE_FIXED
+
     )
     device_type = ObjectVar(
         description="Device model",
         model=DeviceType,
+        default=DEFAULT_DEVICE_TYPE.id,
     )
-    role = ObjectVar(
-        description="Device role",
-        model=DeviceRole,
-        default=ACCESS_SWITCH_DEVICE_ROLE.id,
-    )
+
     site = ObjectVar(
         description = "Site",
         model=Site,
-        default=DEFAULT_SITE.id,
+        default=DEFAULT_SITE,
     )
+
     destination_device = ObjectVar(
         description = "Destination/uplink",
         model=Device,
+        default=DEFAULT_L1_SWITCH.id,
         query_params={
+            'site_id': '$site',
             'role': [DISTRIBUTION_SWITCH_DEVICE_ROLE, ROUTER_DEVICE_ROLE, CORE_DEVICE_ROLE],
         },
     )
     destination_interfaces = MultiObjectVar(
-        description="Destination interface(s)",
+        description="Destination interface(s). \n\n IF You're looking at d1.ring: ge-{PLACEMENT}/x/x. Placements: 0 = South, 1 = Log, 2 = Swing, 3 = North, 4 = noc, 5 = tele",
         model=Interface,
         query_params={
             'device_id': '$destination_device',  
             # ignore interfaces aleady cabled https://github.com/netbox-community/netbox/blob/v3.4.5/netbox/dcim/filtersets.py#L1225
             'cabled': False,
+            'type': '$uplink_type'
         }
     )
-    vlan_group = ObjectVar(
-        label="VLAN Group",
-        description="VLAN Group",
-        model=VLANGroup,
-    )
-    vlan_id = IntegerVar(
-        label="VLAN ID",
-        description="Auto-assigned if not specified. Make sure it is available if you provide it.",
-        required=False,
-        default='',
-    )
-    mgmt_vlan = ObjectVar(
-        description="Management VLAN",
-        model=VLAN,
-        query_params={
-            'group_id': '$vlan_group',
-            'vid': [666, 667],
-        }
-    )
+    # I don't think we'll actually use this
+    #vlan_id = IntegerVar(
+    #    label="VLAN ID",
+    #    description="NB: Only applicable for 'Access' deliveries! Auto-assigned if not specified. Make sure it is available if you provide it.",
+    #    required=False,
+    #    default='',
+    #)
     tags = MultiObjectVar(
         description="Tags to be sent to Gondul. These are used for templating, so be sure what they do.",
         model=Tag,
         required=False,
     )
 
+    nat = BooleanVar(
+        label='NAT?',
+        description="Should the network provided by the switch be NATed?"
+    )
+
+
     def run(self, data, commit):
-        mgmt_vlan = data['mgmt_vlan']
+
+
+        self.log_success(f"{self.request.__dir__()}")
+        self.log_success(f"{self.request.id.__dir__()}")
+        self.log_success(f"{self.request.user}")
+        self.log_success(f"{self.request.META}")
+        # Unfuck shit
+        # Choice var apparently only gives you a string, not an object.
+        # Or i might be stooopid
+        data['leveranse'] = getDeviceRole(data['leveranse'])
+
+        # Let's start with assumptions!
+        # We can generate the name of the vlan. No need to enter manually.
+        # Possbly less confusing so.
+        mgmt_vlan = generateMgmtVlan(self, data)
+        # Make sure that site ang vlan group is the same. Since our vlan boundaries is the same as site
+        vlan_group = VLANGroup.objects.get(slug=data['site'].slug)
 
         # Create the new switch
         switch = Device(
             name=data['switch_name'],
             device_type=data['device_type'],
-            device_role=data['role'],
+            device_role=data['leveranse'],
             site=data['site'],
         )
         switch.save()
+        for tag in data['tags']:
+            switch.tags.add(tag)
         self.log_success(f"Created new switch: <a href=\"{switch.get_absolute_url()}\">{switch}</a>")
 
-        vlan_group = data['vlan_group']
-        vid = vlan_group.get_next_available_vid()
-        # use provided vid if specified.
-        if data['vlan_id']:
-            vid = data['vlan_id']
-        vlan = VLAN.objects.create(
-            name=switch.name,
-            group=vlan_group,
-            vid=vid
-        )
-        vlan.save()
+
+
+        # Only do this if access switch
+        if data['leveranse'].name == "Access Switch":
+            vid = vlan_group.get_next_available_vid()
+            # use provided vid if specified.
+            #if data['vlan_id']:
+            #    vid = data['vlan_id']
+
+            vlan = VLAN.objects.create(
+                name=switch.name,
+                group=vlan_group,
+                vid=vid
+            )
+            vlan.save()
+  
+
+
+        # Only do this if access switch
+        if data['leveranse'].name == "Access Switch":
+            #
+            # Prefixes Part
+            #
+
+            prefixes = Prefix.objects.filter(
+                site = data['site'],
+                status = PrefixStatusChoices.STATUS_CONTAINER,
+                #family = IPAddressFamilyChoices.FAMILY_4,
+                role = Role.objects.get(slug='crew').id
+            )
+
+            if len(prefixes) > 2 or len(prefixes) == 0:
+                raise AbortScript(f"Got two or none prefixes. Run to Simen and ask for help!")
+
+            # Doesn't support anything else than crew networks
+            for prefix in prefixes:
+
+                if prefix.family == 4:
+                    v4_prefix = Prefix.objects.create(
+                        prefix = generatePrefix(prefix, 26),
+                        status = PrefixStatusChoices.STATUS_ACTIVE,
+                        site = data['site'],
+                        role = Role.objects.get(slug='crew'),
+                        vlan = vlan
+                    )
+                    self.log_info(f"Created new IPv4 Prefix: {v4_prefix}")
+                    if data['nat']:
+                        nat = Tag.objects.get(slug='nat')
+                        self.log_info(f"VLAN Id: {nat.name} - {nat.id}")
+                        v4_prefix.tags.add(nat)
+
+                elif prefix.family == 6:
+                    v6_prefix = Prefix.objects.create(
+                        prefix = generatePrefix(prefix, 64),
+                        status = PrefixStatusChoices.STATUS_ACTIVE,
+                        site = data['site'],
+                        role = Role.objects.get(slug='crew'),
+                        vlan = vlan
+                    )
+                    self.log_info(f"IPv6 Prefix: {v6_prefix}")
+                    if data['nat']:
+                        nat = Tag.objects.get(slug='nat')
+                        self.log_info(f"VLAN Id: {nat.name} - {nat.id}")
+                        v6_prefix.tags.add(nat)
+                else:
+                    raise AbortScript(f"Prefix is neither v4 or v6, shouldn't happend!")
+
+
+            #Cheky. But let's resolve the l3 termination hardkoded instead of resolving via netbox.
+            l3Term, l3Intf = getL3(self, data)
+            self.log_success(f"{l3Term} - {l3Intf} - vl{vid}")  
+    
+            l3Uplink = Interface.objects.create(
+                device=l3Term,
+                description = f'C: {switch.name} - VLAN {vlan.id}',
+                name=f"{l3Intf}.{vid}",
+                type=InterfaceTypeChoices.TYPE_VIRTUAL,
+                parent=l3Intf
+            )
+    
+    
+            self.log_success(f"Created Interface: {l3Uplink.name} on {l3Term.name}") 
+
+            v4_uplink_addr = IPAddress.objects.create(
+                address=v4_prefix.get_first_available_ip(),
+            )
+            v6_uplink_addr = IPAddress.objects.create(
+                address=v6_prefix.get_first_available_ip(),
+            )
+            l3Uplink.ip_addresses.add(v4_uplink_addr)
+            l3Uplink.ip_addresses.add(v6_uplink_addr)
+            l3Uplink.tagged_vlans.add(vlan.id)
+
 
         mgmt_vlan_interface = Interface.objects.create(
             device=switch,
             name=f"vlan.{mgmt_vlan.vid}",
+            description = f'X: Mgmt',
             type=InterfaceTypeChoices.TYPE_VIRTUAL,
             mode=InterfaceModeChoices.MODE_TAGGED,
         )
+
         mgmt_vlan_interface.tagged_vlans.add(mgmt_vlan.id)
 
         uplink_ae = Interface.objects.create(
             device=switch,
             name="ae0",
-            description=data['destination_device'].name,
+            description = f"B: {data['destination_device'].name}",
             type=InterfaceTypeChoices.TYPE_LAG,
             mode=InterfaceModeChoices.MODE_TAGGED,
         )
         uplink_ae.tagged_vlans.add(mgmt_vlan.id)
-        uplink_vlan = Interface.objects.create(
-            device=switch,
-            name="ae0.0",
-            description=data['destination_device'].name,
-            type=InterfaceTypeChoices.TYPE_VIRTUAL,
-            parent=uplink_ae,
-        )
+#        uplink_vlan = Interface.objects.create(
+#            device=switch,
+#            name="ae0.0",
+#            description=data['destination_device'].name,
+#            type=InterfaceTypeChoices.TYPE_VIRTUAL,
+#            parent=uplink_ae,
+#        )
+
+        # Hack to create AE name
+        if data['leveranse'].name == "Access Switch":
+            dest_ae_id = vlan.vid
+        elif data['leveranse'].name == "Distribution Switch":
+            dest_ae_id = str(random.randint(5000,6000))
+            self.log_warning("SCRIPT IS GENERATING AE WITH RANDOM NUMBER. PLS FIX ACCORDING TO TEMPLATE :(")
+
         destination_ae = Interface.objects.create(
             device=data['destination_device'],
-            name=f"ae{vlan.vid}",
-            description=switch.name,
+            name=f"ae{dest_ae_id}",
+            description = f'B: {switch.name}',
             type=InterfaceTypeChoices.TYPE_LAG,
             mode=InterfaceModeChoices.MODE_TAGGED,
         )
-        destination_ae.tagged_vlans.add(mgmt_vlan.id)
-        destination_vlan = Interface.objects.create(
-            device=data['destination_device'],
-            name=f"vlan.{vid}",
-            description=switch.name,
-            type=InterfaceTypeChoices.TYPE_VIRTUAL,
-            parent=destination_ae,
-        )
+        if data['leveranse'].name == "Access Switch":        
+            destination_ae.tagged_vlans.add(mgmt_vlan.id)
+            destination_ae.tagged_vlans.add(vlan.id)
         self.log_success("Created AE and VLAN interfaces for both ends")
 
         mgmt_prefix_v4 = mgmt_vlan.prefixes.get(prefix__family=4)
@@ -160,12 +368,18 @@ class CreateSwitch(Script):
         switch.save()
 
         num_uplinks = len(data['destination_interfaces'])
-        interfaces = list(Interface.objects.filter(device=switch).exclude(type=InterfaceTypeChoices.TYPE_VIRTUAL).exclude(type=InterfaceTypeChoices.TYPE_LAG))
+        interfaces = list(Interface.objects.filter(device=switch, type=data['uplink_type']).exclude(type=InterfaceTypeChoices.TYPE_VIRTUAL).exclude(type=InterfaceTypeChoices.TYPE_LAG))
+        if len(interfaces) < 1:
+            raise AbortScript(f"You chose a device type without any {data['uplink_type']} interfaces! Pick another model :)")
         interface_type = ContentType.objects.get_for_model(Interface)
         for uplink_num in range(0, num_uplinks):
             # mark last ports as uplinks
             a_interface = data['destination_interfaces'][::-1][uplink_num]
             b_interface = interfaces[(uplink_num * -1) -1]
+
+            # Fix Descriptions
+            a_interface.description = f'G: {switch.name} (ae0)'
+            b_interface.description = f"G: {data['destination_device'].name} (ae0)"
 
             # Configure uplink as AE0
             b_interface.lag = uplink_ae

--- a/tools/netbox/scripts/create-switch/create-switch.py
+++ b/tools/netbox/scripts/create-switch/create-switch.py
@@ -91,6 +91,7 @@ class CreateSwitch(Script):
     tags = MultiObjectVar(
         description="Tags to be sent to Gondul. These are used for templating, so be sure what they do.",
         model=Tag,
+        required=False,
     )
 
     def run(self, data, commit):

--- a/tools/netbox/scripts/create-switch/create-switch.py
+++ b/tools/netbox/scripts/create-switch/create-switch.py
@@ -193,3 +193,5 @@ class CreateSwitch(Script):
             cable._terminations_modified = True
             cable.save()
             self.log_success(f"Cabled {data['destination_device']} {a_interface} to {switch} {b_interface}")
+
+        self.log_success(f"To create this switch in Gondul you can <a href=\"/extras/scripts/netbox2gondul.Netbox2Gondul/?device={ switch.id }\">trigger an update immediately</a> or <a href=\"{switch.get_absolute_url()}\">view the device</a> first and trigger an update from there.")

--- a/tools/netbox/scripts/create-switch/create-switch.py
+++ b/tools/netbox/scripts/create-switch/create-switch.py
@@ -407,11 +407,14 @@ class CreateSwitch(Script):
         if len(interfaces) < 1:
             raise AbortScript(f"You chose a device type without any {data['uplink_type']} interfaces! Pick another model :)")
         interface_type = ContentType.objects.get_for_model(Interface)
+
+        # Ask Håkon about this, idfk
         for uplink_num in range(0, num_uplinks):
             # mark last ports as uplinks
-            a_interface = data['destination_interfaces'][::-1][uplink_num]
-            b_interface = interfaces[(uplink_num * -1) -1]
-
+            a_interface = data['destination_interfaces'][uplink_num]
+            # Ask Håkon ESPECIALLY about this madness
+            b_interface = interfaces[::-1][0:4][::-1][uplink_num]
+            self.log_debug(f'a_interface: {a_interface}, b_interface: {b_interface}')
             # Fix Descriptions
             a_interface.description = f'G: {switch.name} (ae0)'
             b_interface.description = f"G: {data['destination_device'].name} (ae0)"

--- a/tools/netbox/scripts/create-switch/create-switch.py
+++ b/tools/netbox/scripts/create-switch/create-switch.py
@@ -424,4 +424,17 @@ class CreateSwitch(Script):
             cable.save()
             self.log_success(f"Cabled {data['destination_device']} {a_interface} to {switch} {b_interface}")
 
+        try:
+            uplink_tag = Tag.objects.get(slug=f"{num_uplinks}-uplinks")
+            switch.tags.add(uplink_tag)
+        except Tag.DoesNotExist as e:
+            self.log_error("Failed to find device tag with {num_uplinks} uplinks.")
+            raise e
+
+        uplink_type = data['uplink_type']
+        if uplink_type in [InterfaceTypeChoices.TYPE_10GE_SFP_PLUS, InterfaceTypeChoices.TYPE_10GE_FIXED]:
+            uplink_type_tag = Tag.objects.get(slug="10g-uplink")
+            switch.tags.add(uplink_type_tag)
+            self.log_info(f"Added device tag for 10g uplinks if it wasn't present already: {uplink_type_tag}")
+
         self.log_success(f"To create this switch in Gondul you can <a href=\"/extras/scripts/netbox2gondul.Netbox2Gondul/?device={ switch.id }\">trigger an update immediately</a> or <a href=\"{switch.get_absolute_url()}\">view the device</a> first and trigger an update from there.")

--- a/tools/netbox/scripts/create-switch/create-switch.py
+++ b/tools/netbox/scripts/create-switch/create-switch.py
@@ -9,6 +9,8 @@ from ipam.models import IPAddress, Prefix, VLAN, VLANGroup
 
 # Used for getting existing types/objects from Netbox.
 DISTRIBUTION_SWITCH_DEVICE_ROLE = 'distribution-switch' # match the name or the slug
+ROUTER_DEVICE_ROLE = 'router'
+CORE_DEVICE_ROLE = 'core'
 ACCESS_SWITCH_DEVICE_ROLE = DeviceRole.objects.get(name='Access Switch')
 DEFAULT_SITE = Site.objects.first()  # TODO: pick default site ?
 
@@ -40,7 +42,7 @@ class CreateSwitch(Script):
         description = "Destination/uplink",
         model=Device,
         query_params={
-            'role': DISTRIBUTION_SWITCH_DEVICE_ROLE,
+            'role': [DISTRIBUTION_SWITCH_DEVICE_ROLE, ROUTER_DEVICE_ROLE, CORE_DEVICE_ROLE],
         },
     )
     destination_interfaces = MultiObjectVar(

--- a/tools/netbox/scripts/create-switch/create-switch.py
+++ b/tools/netbox/scripts/create-switch/create-switch.py
@@ -446,6 +446,7 @@ class CreateSwitch(Script):
         try:
             uplink_tag = Tag.objects.get(slug=f"{num_uplinks}-uplinks")
             switch.tags.add(uplink_tag)
+            self.log_info(f"Added tag for number of uplinks if it wasn't present already: {uplink_tag}")
         except Tag.DoesNotExist as e:
             self.log_error("Failed to find device tag with {num_uplinks} uplinks.")
             raise e

--- a/tools/netbox/scripts/create-switch/create-switch.py
+++ b/tools/netbox/scripts/create-switch/create-switch.py
@@ -177,11 +177,11 @@ class CreateSwitch(Script):
             b_interface = interfaces[(uplink_num * -1) -1]
 
             # Configure uplink as AE0
-            b_interface.parent = uplink_ae
+            b_interface.lag = uplink_ae
             b_interface.save()
 
             # Configure downlink on destination
-            a_interface.parent = destination_ae
+            a_interface.lag = destination_ae
             a_interface.save()
 
             cable = Cable.objects.create()

--- a/tools/netbox/scripts/mist2netbox/mist2netbox.py
+++ b/tools/netbox/scripts/mist2netbox/mist2netbox.py
@@ -28,20 +28,19 @@ WIFI_TAGS = [TG(slug="deltagere")]
 
 def fetch_from_mist():
     site = None
-    auth = None
+    token = None
     with open(CONFIG_FILE, 'r') as f:
         contents = f.read()
         j = json.loads(contents)
         site = j['site']
-        auth = j['auth']
+        token = j['token']
 
     site_url = f"https://api.eu.mist.com/api/v1/sites/{site}/stats/devices"
     resp = requests.get(site_url,
         None,
         headers={
-           # 'authorization': f'Bearer {TOKEN}',
+           'authorization': f'Token {token}',
         },
-        cookies={'sessionid.eu': auth},
     )
     return resp.json()
 

--- a/tools/netbox/scripts/mist2netbox/mist2netbox.py
+++ b/tools/netbox/scripts/mist2netbox/mist2netbox.py
@@ -197,7 +197,7 @@ class Mist2Netbox(Script):
             device.save()
 
             if "locating" in device_data and device_data["locating"]:
-                locating_tag = Tag.objects.get_or_create(name="locating")
+                locating_tag, _ = Tag.objects.get_or_create(name="locating")
                 device.tags.add(locating_tag)
 
 

--- a/tools/netbox/scripts/mist2netbox/mist2netbox.py
+++ b/tools/netbox/scripts/mist2netbox/mist2netbox.py
@@ -58,8 +58,10 @@ def create_device_from_mist(data):
 def get_distro_from_mist(data):
     if 'lldp_stat' not in data:
         return None, None
+    distro_name = data['lldp_stat']['system_name']
+    distro_name = distro_name.replace(".tg23.gathering.org", "")
     try:
-        distro = Device.objects.get(name=data['lldp_stat']['system_name'])
+        distro = Device.objects.get(name=distro_name)
         distro_port = distro.interfaces.get(name=data['lldp_stat']['port_id'])
         return distro, distro_port
     except Device.DoesNotExist:

--- a/tools/netbox/scripts/mist2netbox/mist2netbox.py
+++ b/tools/netbox/scripts/mist2netbox/mist2netbox.py
@@ -196,6 +196,11 @@ class Mist2Netbox(Script):
             device.primary_ip6 = mgmt_addr_v6
             device.save()
 
+            if "locating" in device_data and device_data["locating"]:
+                locating_tag = Tag.objects.get_or_create(name="locating")
+                device.tags.add(locating_tag)
+
+
             # Add tag to everything we created so it's easy to identify in case we
             # want to recreate
             things_we_created = [

--- a/tools/netbox/scripts/mist2netbox/mist2netbox.py
+++ b/tools/netbox/scripts/mist2netbox/mist2netbox.py
@@ -18,7 +18,7 @@ CONFIG_FILE = '/etc/netbox/scripts/mist.json'
 AP_DEVICE_ROLE = DeviceRole.objects.get(name='AP')
 DEFAULT_SITE = Site.objects.get(slug='hele-skpet')
 WIFI_MGMT_VLAN = VLAN.objects.get(name="wifi-mgmt.floor.r1.tele")
-WIFI_TRAFFIC_VLAN = VLAN.objects.get(name="wifi-clients-ssid-the-gathering.floor.r1.tele")
+WIFI_TRAFFIC_VLAN = VLAN.objects.get(name="wifi-lol")
 CORE_DEVICE = Device.objects.get(name="r1.tele")
 
 TG = Tag.objects.get

--- a/tools/netbox/scripts/mist2netbox/mist2netbox.py
+++ b/tools/netbox/scripts/mist2netbox/mist2netbox.py
@@ -1,0 +1,200 @@
+import json
+import requests
+
+from django.contrib.contenttypes.models import ContentType
+
+from dcim.choices import InterfaceModeChoices, InterfaceTypeChoices
+from dcim.models import Cable, CableTermination, Device, DeviceRole, DeviceType, Interface, Site
+from extras.models import Tag
+from extras.scripts import *
+from ipam.models import IPAddress, Prefix, VLAN, VLANGroup
+from netaddr import IPNetwork
+
+
+CONFIG_FILE = '/etc/netbox/scripts/mist.json'
+
+# Used for getting existing types/objects from Netbox.
+AP_DEVICE_ROLE = DeviceRole.objects.get(name='AP')
+DEFAULT_SITE = Site.objects.get(slug='hele-skpet')
+WIFI_MGMT_VLAN = VLAN.objects.get(name="wifi-mgmt.floor.r1.tele")
+WIFI_TRAFFIC_VLAN = VLAN.objects.get(name="wifi-clients-ssid-the-gathering.floor.r1.tele")
+CORE_DEVICE = Device.objects.get(name="r1.tele")
+
+TG = Tag.objects.get
+WIFI_TAGS = [TG(slug="deltagere")]
+
+# TODO: "distro" needs various tags, auto-add ? or warn in gondul?
+
+def fetch_from_mist():
+    site = None
+    auth = None
+    with open(CONFIG_FILE, 'r') as f:
+        contents = f.read()
+        j = json.loads(contents)
+        site = j['site']
+        auth = j['auth']
+
+    site_url = f"https://api.eu.mist.com/api/v1/sites/{site}/stats/devices"
+    resp = requests.get(site_url,
+        None,
+        headers={
+           # 'authorization': f'Bearer {TOKEN}',
+        },
+        cookies={'sessionid.eu': auth},
+    )
+    return resp.json()
+
+def create_device_from_mist(data):
+    model = DeviceType.objects.get(model=data['model'])
+    device, _created = Device.objects.get_or_create(
+        name=data['name'],
+        device_role=AP_DEVICE_ROLE,
+        device_type=model,
+        site=DEFAULT_SITE,
+    )
+
+    return device
+
+def get_distro_from_mist(data):
+    if 'lldp_stat' not in data:
+        return None, None
+    try:
+        distro = Device.objects.get(name=data['lldp_stat']['system_name'])
+        distro_port = distro.interfaces.get(name=data['lldp_stat']['port_id'])
+        return distro, distro_port
+    except Device.DoesNotExist:
+        return None, None
+
+class Mist2Netbox(Script):
+
+    class Meta:
+        name = "Mist to netbox"
+        description = "Import devices from Mist to Netbox"
+        commit_default = False
+        field_order = ['site_name', 'switch_count', 'switch_model']
+        fieldsets = ""
+
+    def run(self, data, commit):
+
+        devices = fetch_from_mist()
+
+        import_tag, _created = Tag.objects.get_or_create(name="from-mist")
+
+        self.log_info(f"Importing {len(devices)} switches")
+        for device_data in devices:
+            self.log_debug(f"Managing device from {device_data}")
+
+            device = create_device_from_mist(device_data)
+            
+            self.log_debug(f"Managing {device}")
+
+            distro, distro_port = get_distro_from_mist(device_data)
+            if not distro and not distro_port:
+                self.log_warning(f"Skipping {device}, missing distro information")
+                device.delete()
+                continue
+
+
+            mgmt_vlan = WIFI_MGMT_VLAN
+
+            interface = None
+            interface, _created_interface = Interface.objects.get_or_create(
+                device=device,
+                name="eth0",
+            )
+            interface.description = distro.name
+            interface.mode = InterfaceModeChoices.MODE_TAGGED
+            interface.save()
+            interface.tagged_vlans.add(mgmt_vlan)
+            
+            # distro side
+            distro_interface, _created_distro_interface = Interface.objects.get_or_create(
+                device=distro,
+                name=distro_port,
+            )
+            distro_interface.description = device.name
+            distro_interface.mode = InterfaceModeChoices.MODE_TAGGED
+            distro_interface.save()
+            distro_interface.tagged_vlans.add(mgmt_vlan)
+
+            interface.tagged_vlans.add(WIFI_TRAFFIC_VLAN)
+
+
+            # Cabling
+            interface_type = ContentType.objects.get_for_model(Interface)
+            # Delete A cable termination if it exists
+            try:
+                CableTermination.objects.get(
+                    cable_end='A',
+                    termination_id=distro_interface.id,
+                    termination_type=interface_type,
+                ).delete()
+            except CableTermination.DoesNotExist:
+                pass
+
+            # Delete B cable termination if it exists
+            try:
+                CableTermination.objects.get(
+                    cable_end='B',
+                    termination_id=interface.id,
+                    termination_type=interface_type,
+                ).delete()
+            except CableTermination.DoesNotExist:
+                pass
+            
+            # Create cable now that we've cleaned up the cable mess.
+            cable = Cable.objects.create()
+            a = CableTermination.objects.create(
+                cable=cable,
+                cable_end='A',
+                termination_id=distro_interface.id,
+                termination_type=interface_type,
+            )
+            b = CableTermination.objects.create(
+                cable_end='B',
+                cable=cable,
+                termination_id=interface.id,
+                termination_type=interface_type,
+            )
+
+            cable = Cable.objects.get(id=cable.id)
+            # https://github.com/netbox-community/netbox/discussions/10199
+            cable._terminations_modified = True
+            cable.save()
+            cable.tags.add(import_tag)
+
+            # Set mgmt ip
+            mgmt_addr_ipv4 = device_data['ip_stat']['ip']
+            mgmt_addr_ipv4_netmask = device_data['ip_stat']['netmask']
+            mgmt_addr_v4 = f"{mgmt_addr_ipv4}/25"  # netmask is in cidr notation, and netmask6 is in prefix notation. why?
+            if device.primary_ip4 != mgmt_addr_v4:
+                device.primary_ip4.delete()
+            mgmt_addr_v4, _ = IPAddress.objects.get_or_create(
+                address=mgmt_addr_v4,
+                assigned_object_type=interface_type,
+                assigned_object_id=interface.id,
+            )
+            mgmt_addr_ipv6 = device_data['ip_stat']['ip6']
+            mgmt_addr_ipv6_netmask = device_data['ip_stat']['netmask6']
+            mgmt_addr_v6 = f"{mgmt_addr_ipv6}{mgmt_addr_ipv6_netmask}"
+            if device.primary_ip6 != mgmt_addr_v6:
+                device.primary_ip6.delete()
+            mgmt_addr_v6, _ = IPAddress.objects.get_or_create(
+                address=mgmt_addr_v6,
+                assigned_object_type=interface_type,
+                assigned_object_id=interface.id,
+            )
+            device = Device.objects.get(pk=device.pk)
+            device.primary_ip4 = mgmt_addr_v4
+            device.primary_ip6 = mgmt_addr_v6
+            device.save()
+
+            # Add tag to everything we created so it's easy to identify in case we
+            # want to recreate
+            things_we_created = [
+                device,
+                mgmt_addr_v4,
+                mgmt_addr_v6,
+            ]
+            for thing in things_we_created:
+                thing.tags.add(import_tag)

--- a/tools/netbox/scripts/mist2netbox/mist2netbox.py
+++ b/tools/netbox/scripts/mist2netbox/mist2netbox.py
@@ -167,7 +167,7 @@ class Mist2Netbox(Script):
             mgmt_addr_ipv4 = device_data['ip_stat']['ip']
             mgmt_addr_ipv4_netmask = device_data['ip_stat']['netmask']
             mgmt_addr_v4 = f"{mgmt_addr_ipv4}/25"  # netmask is in cidr notation, and netmask6 is in prefix notation. why?
-            if device.primary_ip4 != mgmt_addr_v4:
+            if device.primary_ip4 and device.primary_ip4 != mgmt_addr_v4:
                 device.primary_ip4.delete()
             mgmt_addr_v4, _ = IPAddress.objects.get_or_create(
                 address=mgmt_addr_v4,
@@ -177,7 +177,7 @@ class Mist2Netbox(Script):
             mgmt_addr_ipv6 = device_data['ip_stat']['ip6']
             mgmt_addr_ipv6_netmask = device_data['ip_stat']['netmask6']
             mgmt_addr_v6 = f"{mgmt_addr_ipv6}{mgmt_addr_ipv6_netmask}"
-            if device.primary_ip6 != mgmt_addr_v6:
+            if device.primary_ip6 and device.primary_ip6 != mgmt_addr_v6:
                 device.primary_ip6.delete()
             mgmt_addr_v6, _ = IPAddress.objects.get_or_create(
                 address=mgmt_addr_v6,

--- a/tools/netbox/scripts/mist2netbox/mist2netbox.py
+++ b/tools/netbox/scripts/mist2netbox/mist2netbox.py
@@ -204,4 +204,6 @@ class Mist2Netbox(Script):
                 mgmt_addr_v6,
             ]
             for thing in things_we_created:
+                if not thing:
+                    continue
                 thing.tags.add(import_tag)

--- a/tools/netbox/scripts/mist2netbox/mist2netbox.py
+++ b/tools/netbox/scripts/mist2netbox/mist2netbox.py
@@ -189,6 +189,8 @@ class Mist2Netbox(Script):
                     assigned_object_type=interface_type,
                     assigned_object_id=interface.id,
                 )
+            else:
+                mgmt_addr_v6 = None
             device = Device.objects.get(pk=device.pk)
             device.primary_ip4 = mgmt_addr_v4
             device.primary_ip6 = mgmt_addr_v6

--- a/tools/netbox/scripts/mist2netbox/mist2netbox.py
+++ b/tools/netbox/scripts/mist2netbox/mist2netbox.py
@@ -196,10 +196,12 @@ class Mist2Netbox(Script):
             device.primary_ip6 = mgmt_addr_v6
             device.save()
 
-            if "locating" in device_data and device_data["locating"]:
+            if "locating" in device_data:
                 locating_tag, _ = Tag.objects.get_or_create(name="locating")
-                device.tags.add(locating_tag)
-
+                if device_data["locating"]:
+                    device.tags.add(locating_tag)
+                else:
+                    device.tags.remove(locating_tag)
 
             # Add tag to everything we created so it's easy to identify in case we
             # want to recreate

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -205,8 +205,8 @@ class Netbox2Gondul(Script):
         # sanity check
         for device in input_devices:
             if not device.primary_ip4 and not device.primary_ip6:
-                self.log_failure(f'Device <a href="{device.get_absolute_url()}">{device.name}</a> is missing primary IPv4 and IPv6 address.')
-                return
+                self.log_warning(f'Device <a href="{device.get_absolute_url()}">{device.name}</a> is missing primary IPv4 and IPv6 address, skipping...')
+                continue
 
             vlan: VLAN = None
             prefix_v4: Prefix = None
@@ -224,8 +224,8 @@ class Netbox2Gondul(Script):
                 self.log_warning(f'Device <a href="{device.get_absolute_url()}">{device.name}</a> is missing primary IPv6 address.')
 
             if prefix_v4 is not None and prefix_v6 is not None and prefix_v4.vlan != prefix_v6.vlan:
-                self.log_failure(f'VLANs differ for the IPv4 and IPv6 addresses.')
-                return
+                self.log_warning(f'VLANs differ for the IPv4 and IPv6 addresses, skipping...')
+                continue
 
 
             networks.append(self.network_to_gondul_format(vlan, prefix_v4, prefix_v6))

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -244,7 +244,7 @@ class Netbox2Gondul(Script):
                 continue
 
             prefix_v6: Prefix = None
-            if device.primary_ip6 and IPv6Address(str(device.primary_ip6.ip)).is_global:
+            if device.primary_ip6 and IPv6Address(str(device.primary_ip6).split('/')[0]).is_global:
                 prefix_v6 = Prefix.objects.get(NetHostContained(F('prefix'), str(device.primary_ip6)))
                 vlan = prefix_v6.vlan
             else:

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -177,7 +177,7 @@ class Netbox2Gondul(Script):
             # "placement": "", # Not implemented
             # "poll_frequency": "", # Not implemented
             "sysname": device.name,
-            "traffic_vlan": traffic_vlan_name, # Not implemented
+            "traffic_vlan": traffic_vlan_name,
             # "deleted": False,  # Not implemented
         }]
 

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -20,7 +20,7 @@ from requests.models import HTTPBasicAuth
 FLOOR = Site.objects.get(slug="floor")
 RING = Site.objects.get(slug="ring")
 WIFI = Site.objects.get(slug="hele-skpet")
-WIFI_TRAFFIC_VLAN = VLAN.objects.get(name="wifi-clients-ssid-the-gathering.floor.r1.tele")
+WIFI_TRAFFIC_VLAN = VLAN.objects.get(name="wifi-lol")
 
 class GondulConfigError(Exception):
     def __init__(self, msg):

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -178,7 +178,7 @@ class Netbox2Gondul(Script):
         else:
             self.log_failure(f"Gondul said HTTP {req.status_code} and {req.text}")
 
-    def run(self, data):
+    def run(self, data, commit):
         device: Device = data['device']
 
         if not device.primary_ip4 and not device.primary_ip6:

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -67,8 +67,8 @@ class Netbox2Gondul(Script):
             router = "r1.tele"
 
         vlan_name = vlan.name
-        if 'gondul-name:' in vlan.description:
-            override = vlan.description.split('gondul-name:')[1].split()[0]
+        if vlan.custom_fields.filter(name='gondul_name').count() == 1 and vlan.cf['gondul_name']:
+            override = vlan.cf['gondul_name']
             self.log_info(f'Overriding management vlan name with: {override} (was: {vlan_name})')
             vlan_name = override
         vlan_name += f".{router}"
@@ -113,8 +113,8 @@ class Netbox2Gondul(Script):
         # to make sure we only pick management VLANs
 
         mgmt_vlan_name = mgmt_vlan.name
-        if 'gondul-name:' in mgmt_vlan.description:
-            override = mgmt_vlan.description.split('gondul-name:')[1].split()[0]
+        if mgmt_vlan.custom_fields.filter(name='gondul_name').count() == 1 and mgmt_vlan.cf['gondul_name']:
+            override = mgmt_vlan.cf['gondul_name']
             self.log_info(f'Overriding management vlan name with: {override} (was: {mgmt_vlan_name})')
             mgmt_vlan_name = override
 

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -248,8 +248,7 @@ class Netbox2Gondul(Script):
                 prefix_v6 = Prefix.objects.get(NetHostContained(F('prefix'), str(device.primary_ip6)))
                 vlan = prefix_v6.vlan
             else:
-                self.log_warning(f'Device <a href="{device.get_absolute_url()}">{device.name}</a> is missing global primary IPv6 address. Skipping.')
-                continue
+                self.log_warning(f'Device <a href="{device.get_absolute_url()}">{device.name}</a> is missing global primary IPv6 address.')
 
             if not vlan:
                 self.log_warning(f"Skipping {device}: missing vlan")

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -104,13 +104,13 @@ class Netbox2Gondul(Script):
         router = None
 
         if prefix_v4:
-            subnet4 = str(prefix_v4.prefix)
+            subnet4 = prefix_v4.prefix
             gw4 = str(ipaddress.IPv4Network(prefix_v4.prefix)[1])
         else:
             self.log_warning(f'Network for VLAN <a href="{vlan.get_absolute_url()}">{vlan.name}</a> is missing IPv4 Prefix')
 
         if prefix_v6:
-            subnet6 = str(prefix_v6.prefix)
+            subnet6 = prefix_v6.prefix
             gw6 = str(ipaddress.IPv6Network(prefix_v6.prefix)[1])
         else:
             self.log_warning(f'Network for VLAN <a href="{vlan.get_absolute_url()}">{vlan.name}</a> is missing IPv6 Prefix')
@@ -128,8 +128,8 @@ class Netbox2Gondul(Script):
             vlan_name = override
         return {
             "name": vlan_name,
-            "subnet4": subnet4,
-            "subnet6": subnet6,
+            "subnet4": str(subnet4),
+            "subnet6": str(subnet6),
             "gw4": gw4,
             "gw6": gw6,
             "router": router,

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -211,8 +211,12 @@ class Netbox2Gondul(Script):
             vlan: VLAN = None
             prefix_v4: Prefix = None
             if device.primary_ip4:
-                prefix_v4 = Prefix.objects.get(NetHostContained(F('prefix'), str(device.primary_ip4)))
-                vlan = prefix_v4.vlan
+                try:
+                    prefix_v4 = Prefix.objects.get(NetHostContained(F('prefix'), str(device.primary_ip4)))
+                    vlan = prefix_v4.vlan
+                except Exception as e:
+                    self.log_warning(f"Failed to configure {device} for import: {e}")
+                    continue
             else:
                 self.log_warning(f'Device <a href="{device.get_absolute_url()}">{device.name}</a> is missing primary IPv4 address.')
 

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -161,6 +161,7 @@ class Netbox2Gondul(Script):
             traffic_vlan = VLAN.objects.get(name=device.name)
             traffic_prefix_v4 = Prefix.objects.get(vlan=traffic_vlan, prefix__family=4)
             traffic_prefix_v6 = Prefix.objects.get(vlan=traffic_vlan, prefix__family=6)
+            traffic_vlan_name = traffic_vlan.name
 
             self.network_to_gondul(traffic_vlan, traffic_prefix_v4, traffic_prefix_v6)
         except VLAN.DoesNotExist:

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -155,7 +155,7 @@ class Netbox2Gondul(Script):
         cable: Cable = first_ae_interface.cable
         # Assuming we only have one entry in the cable termination list.
         distro_interface: Interface = cable.a_terminations[0]
-        distro = distro_interface.device
+        distro = distro_interface.device if distro_interface.device != device else cable.b_terminations[0].device
 
         # This is the same way as we fetch mgmt vlan in the main run() function.
         # We could pass it in directly to device_to_gondul().

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -116,7 +116,7 @@ class Netbox2Gondul(Script):
             self.log_warning(f'Network for VLAN <a href="{vlan.get_absolute_url()}">{vlan.name}</a> is missing IPv6 Prefix')
 
         try:
-            router = str(IPAddress.objects.get(address=gw4))
+            router = str(IPAddress.objects.get(address=f"{gw4}/{subnet4.prefixlen}"))
         except IPAddress.DoesNotExist:
             self.log_warning(f'Router not found for VLAN <a href="{vlan.get_absolute_url()}">{vlan.name}</a>')
             router = "r1.tele"

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -10,6 +10,7 @@ from ipam.lookups import NetContainsOrEquals
 
 import ipaddress
 import json
+import re
 import requests
 from requests.models import HTTPBasicAuth
 
@@ -25,10 +26,10 @@ class Netbox2Gondul(Script):
 
     class Meta:
         name = "Sync NetBox to Gondul"
-        description = """
+        description = re.sub(r'^\s*', '', """
             Can be done for a single network/device or a full sync. Note that this will not do 'renames' of devices, so it is best used for updating device information.
             If a device is selected, it will also sync the required networks as long as they are set up correctly (Primary IP addresses for the Switch & VLAN configured for the Prefix of those IP Addresses).
-        """
+        """)
         field_order = ['site_name', 'switch_count', 'switch_model']
 
     switch = ObjectVar(

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -113,7 +113,6 @@ class Netbox2Gondul(Script):
             override = vlan.cf['gondul_name']
             self.log_info(f'Overriding management vlan name with: {override} (was: {vlan_name})')
             vlan_name = override
-        vlan_name += f".{router}"
 
         networks = [{
             "name": vlan_name,
@@ -156,10 +155,6 @@ class Netbox2Gondul(Script):
             override = mgmt_vlan.cf['gondul_name']
             self.log_info(f'Overriding management vlan name with: {override} (was: {mgmt_vlan_name})')
             mgmt_vlan_name = override
-
-        # add name of router to vlan name
-        router = "r1.tele"
-        mgmt_vlan_name += f".{router}"
 
         switches = [{
             # "community": "", # Not implemented

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -1,0 +1,166 @@
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import F
+from django.utils.text import slugify
+
+from dcim.choices import DeviceStatusChoices, InterfaceModeChoices, InterfaceTypeChoices, SiteStatusChoices
+from dcim.models import Cable, CableTermination, Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
+from extras.scripts import *
+from ipam.models import IPAddress, Prefix, VLAN
+from ipam.lookups import NetContainsOrEquals
+
+import ipaddress
+import json
+import requests
+from requests.models import HTTPBasicAuth
+
+GONDUL_URL = ""
+GONDUL_USERNAME = ""
+GONDUL_PASSWORD = ""
+
+def find_prefix_for_device(device) -> Prefix:
+    pass
+
+
+class Netbox2Gondul(Script):
+
+    class Meta:
+        name = "Sync NetBox to Gondul"
+        description = """
+            Can be done for a single network/device or a full sync. Note that this will not do 'renames' of devices, so it is best used for updating device information.
+            If a device is selected, it will also sync the required networks as long as they are set up correctly (Primary IP addresses for the Switch & VLAN configured for the Prefix of those IP Addresses).
+        """
+        field_order = ['site_name', 'switch_count', 'switch_model']
+
+    switch = ObjectVar(
+        description="Switch",
+        model=Device,
+        required=True,
+    )
+    """
+    vlan = ObjectVar(
+        description="VLAN",
+        model=VLAN,
+        required=False,
+    )
+    prefix_v4 = ObjectVar(
+        description="IPv4 Prefix",
+        model=Prefix,
+        query_params={
+            'family': 4,
+            'vlan_id': '$vlan'
+        },
+        required=False,
+    )
+    prefix_v6 = ObjectVar(
+        description="IPv6 Prefix",
+        model=Prefix,
+        query_params={
+            'family': 6,
+            'vlan_id': '$vlan'
+        },
+        required=False,
+    )
+    """
+
+    def network_to_gondul(self, vlan: VLAN, prefix_v4: Prefix, prefix_v6: Prefix):
+        self.log_info(f"Posting {vlan.name} to Gondul")
+
+        gondul_auth = HTTPBasicAuth(GONDUL_USERNAME, GONDUL_PASSWORD)
+    
+        subnet4 = None
+        subnet6 = None
+        gw4 = None
+        gw6 = None
+        router = None
+
+        if prefix_v4:
+            subnet4 = str(prefix_v4.prefix)
+            gw4 = ipaddress.IPv4Network(prefix_v4.prefix)[1].exploded
+        else:
+            self.log_warning(f'Network for VLAN <a href="{vlan.get_absolute_url()}">{vlan.name}</a> is missing IPv4 Prefix')
+
+        if prefix_v6:
+            subnet6 = str(prefix_v6.prefix)
+            gw6 = ipaddress.IPv6Network(prefix_v6.prefix)[1].exploded
+        else:
+            self.log_warning(f'Network for VLAN <a href="{vlan.get_absolute_url()}">{vlan.name}</a> is missing IPv6 Prefix')
+
+        try:
+            router = IPAddress.objects.get(address=gw4)
+        except IPAddress.DoesNotExist:
+            self.log_warning(f'Router not found for VLAN <a href="{vlan.get_absolute_url()}">{vlan.name}</a>')
+
+        data = json.dumps([{
+            "name": vlan.name,
+            "subnet4": subnet4,
+            "subnet6": subnet6,
+            "gw4": gw4,
+            "gw6": gw6,
+            "router": router,
+            "vlan": vlan.vid,
+        }])
+
+        req = requests.post(
+            f"{GONDUL_URL}/api/write/networks",
+            data=data,
+            headers={'content-type': 'application/json'},
+            auth=gondul_auth,
+        )
+
+        if req.ok:
+            self.log_success(f"Gondul said (HTTP {req.status_code}): {req.text}")
+        else:
+            self.log_failure(f"Gondul said HTTP {req.status_code} and {req.text}")
+
+    def device_to_gondul(self, device: Device):
+        self.log_info(f"Posting {device.name} to Gondul")
+ 
+        gondul_auth = HTTPBasicAuth(GONDUL_USERNAME, GONDUL_PASSWORD)
+
+        data = json.dumps([
+        ])
+
+        req = requests.post(
+            f"{GONDUL_URL}/api/write/switches",
+            data=data,
+            headers={'content-type': 'application/json'},
+            auth=gondul_auth,
+        )
+
+        if req.ok:
+            self.log_success(f"Gondul said (HTTP {req.status_code}): {req.text}")
+        else:
+            self.log_failure(f"Gondul said HTTP {req.status_code} and {req.text}")
+
+    def run(self, data, commit):
+
+        switch: Device = data['switch']
+        """
+        vlan: VLAN = data['vlan']
+        prefix_v4: Prefix = data['prefix_v4']
+        prefix_v6: Prefix = data['prefix_v6']
+        """
+
+        """
+            if prefix_v4 is None:
+                self.log_info(f"v4 not provided, default")
+        """
+
+        if not (switch.primary_ip4 or switch.primary_ip6):
+            self.log_failure(f'Switch <a href="{switch.get_absolute_url()}">{switch.name}</a> is missing primary IPv4 or IPv6 address.')
+            return
+
+        prefix_v4 = Prefix.objects.get(NetContainsOrEquals(F('prefix'), str(switch.primary_ip4.address)))
+        prefix_v6 = Prefix.objects.get(NetContainsOrEquals(F('prefix'), str(switch.primary_ip6.address)))
+
+        vlan = prefix_v6.vlan
+
+        if prefix_v4.vlan != prefix_v6.vlan:
+            self.log_failure(f'VLANs differ for the IPv4 and IPv6 addresses.')
+            return
+
+        self.network_to_gondul(vlan, prefix_v4, prefix_v6)
+
+        self.log_success("All good, sending to Gondul")
+
+        self.device_to_gondul(switch)

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -7,6 +7,7 @@ from django.utils.text import slugify
 from dcim.choices import DeviceStatusChoices, InterfaceModeChoices, InterfaceTypeChoices, SiteStatusChoices
 from dcim.models import Cable, CableTermination, Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
 from extras.scripts import *
+from ipaddress import IPv6Address
 from ipam.models import IPAddress, Prefix, VLAN
 from ipam.lookups import NetHostContained
 
@@ -243,11 +244,11 @@ class Netbox2Gondul(Script):
                 continue
 
             prefix_v6: Prefix = None
-            if device.primary_ip6:
+            if device.primary_ip6 and IPv6Address(str(device.primary_ip6)).is_global:
                 prefix_v6 = Prefix.objects.get(NetHostContained(F('prefix'), str(device.primary_ip6)))
                 vlan = prefix_v6.vlan
             else:
-                self.log_warning(f'Device <a href="{device.get_absolute_url()}">{device.name}</a> is missing primary IPv6 address. Skipping.')
+                self.log_warning(f'Device <a href="{device.get_absolute_url()}">{device.name}</a> is missing global primary IPv6 address. Skipping.')
                 continue
 
             if not vlan:

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -134,6 +134,7 @@ class Netbox2Gondul(Script):
             "gw6": gw6,
             "router": router,
             "vlan": vlan.vid,
+            "tags": [tag.slug for tag in list(vlan.tags.all())],
         }
 
     def switches_to_gondul(self, switches):

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -145,9 +145,11 @@ class Netbox2Gondul(Script):
         distro_interface: Interface = cable.a_terminations[0]
         distro = distro_interface.device
 
-        mgmt_vlan = uplink_ae.tagged_vlans.first()
-        # Could consider filtering interfaces for: filter(Q(is_management=True) | Q(description__icontains="management")).first()
-        # to make sure we only pick management VLANs
+        # This is the same way as we fetch mgmt vlan in the main run() function.
+        # We could pass it in directly to device_to_gondul().
+        mgmt_ip_addr = device.primary_ip4 if device.primary_ip4 is not None else device.primary_ip6
+        mgmt_prefix = Prefix.objects.get(NetHostContained(F('prefix'), str(mgmt_ip_addr)))
+        mgmt_vlan = mgmt_prefix.vlan
 
         mgmt_vlan_name = mgmt_vlan.name
         if mgmt_vlan.custom_fields.filter(name='gondul_name').count() == 1 and mgmt_vlan.cf['gondul_name']:

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -154,8 +154,8 @@ class Netbox2Gondul(Script):
         first_ae_interface: Interface = uplink_ae.member_interfaces.first()
         cable: Cable = first_ae_interface.cable
         # Assuming we only have one entry in the cable termination list.
-        distro_interface: Interface = cable.a_terminations[0]
-        distro = distro_interface.device if distro_interface.device != device else cable.b_terminations[0].device
+        distro_interface: Interface = cable.a_terminations[0] if cable.a_terminations[0].device != device else cable.b_terminations[0]
+        distro = distro_interface.device
 
         # This is the same way as we fetch mgmt vlan in the main run() function.
         # We could pass it in directly to device_to_gondul().

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -1,7 +1,7 @@
 import os
 
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import F
+from django.db.models import F, Q
 from django.utils.text import slugify
 
 from dcim.choices import DeviceStatusChoices, InterfaceModeChoices, InterfaceTypeChoices, SiteStatusChoices
@@ -15,6 +15,9 @@ import json
 import re
 import requests
 from requests.models import HTTPBasicAuth
+
+FLOOR = Site.objects.get(slug="floor")
+RING = Site.objects.get(slug="ring")
 
 class GondulConfigError(Exception):
     def __init__(self, msg):
@@ -197,7 +200,11 @@ class Netbox2Gondul(Script):
         input_devices: list[Type[Device]] = data['device']
 
         if len(input_devices) == 0:
-            input_devices = Device.objects.filter(status=DeviceStatusChoices.STATUS_ACTIVE)
+            input_devices = Device.objects.filter(
+                Q(site=FLOOR) | Q(site=RING)
+            ).filter(
+                status=DeviceStatusChoices.STATUS_ACTIVE,
+            )
 
         networks = []
         switches = []

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -36,31 +36,6 @@ class Netbox2Gondul(Script):
         model=Device,
         required=True,
     )
-    """
-    vlan = ObjectVar(
-        description="VLAN",
-        model=VLAN,
-        required=False,
-    )
-    prefix_v4 = ObjectVar(
-        description="IPv4 Prefix",
-        model=Prefix,
-        query_params={
-            'family': 4,
-            'vlan_id': '$vlan'
-        },
-        required=False,
-    )
-    prefix_v6 = ObjectVar(
-        description="IPv6 Prefix",
-        model=Prefix,
-        query_params={
-            'family': 6,
-            'vlan_id': '$vlan'
-        },
-        required=False,
-    )
-    """
 
     def network_to_gondul(self, vlan: VLAN, prefix_v4: Prefix, prefix_v6: Prefix):
         self.log_info(f"Posting {vlan.name} to Gondul")

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -244,7 +244,7 @@ class Netbox2Gondul(Script):
                 continue
 
             prefix_v6: Prefix = None
-            if device.primary_ip6 and IPv6Address(str(device.primary_ip6)).is_global:
+            if device.primary_ip6 and IPv6Address(str(device.primary_ip6.ip)).is_global:
                 prefix_v6 = Prefix.objects.get(NetHostContained(F('prefix'), str(device.primary_ip6)))
                 vlan = prefix_v6.vlan
             else:

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -18,6 +18,7 @@ from requests.models import HTTPBasicAuth
 
 FLOOR = Site.objects.get(slug="floor")
 RING = Site.objects.get(slug="ring")
+WIFI = Site.objects.get(slug="hele-skpet")
 WIFI_TRAFFIC_VLAN = VLAN.objects.get(name="wifi-clients-ssid-the-gathering.floor.r1.tele")
 
 class GondulConfigError(Exception):
@@ -214,7 +215,7 @@ class Netbox2Gondul(Script):
 
         if len(input_devices) == 0:
             input_devices = Device.objects.filter(
-                Q(site=FLOOR) | Q(site=RING)
+                Q(site=FLOOR) | Q(site=RING) | Q(site=WIFI)
             ).filter(
                 status=DeviceStatusChoices.STATUS_ACTIVE,
             )

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -8,7 +8,7 @@ from dcim.choices import DeviceStatusChoices, InterfaceModeChoices, InterfaceTyp
 from dcim.models import Cable, CableTermination, Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
 from extras.scripts import *
 from ipam.models import IPAddress, Prefix, VLAN
-from ipam.lookups import NetContainsOrEquals
+from ipam.lookups import NetHostContained
 
 import ipaddress
 import json
@@ -191,14 +191,14 @@ class Netbox2Gondul(Script):
         vlan: VLAN = None
         prefix_v4: Prefix = None
         if device.primary_ip4:
-            prefix_v4 = Prefix.objects.get(NetContainsOrEquals(F('prefix'), str(device.primary_ip4.address)))
+            prefix_v4 = Prefix.objects.get(NetHostContained(F('prefix'), str(device.primary_ip4)))
             vlan = prefix_v4.vlan
         else:
             self.log_warning(f'Device <a href="{device.get_absolute_url()}">{device.name}</a> is missing primary IPv4 address.')
 
         prefix_v6: Prefix = None
         if device.primary_ip6:
-            prefix_v6 = Prefix.objects.get(NetContainsOrEquals(F('prefix'), str(device.primary_ip6.address)))
+            prefix_v6 = Prefix.objects.get(NetHostContained(F('prefix'), str(device.primary_ip6)))
             vlan = prefix_v6.vlan
         else:
             self.log_warning(f'Device <a href="{device.get_absolute_url()}">{device.name}</a> is missing primary IPv6 address.')

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -196,7 +196,8 @@ class Netbox2Gondul(Script):
         return {
             # "community": "", # Not implemented
             "tags": [tag.slug for tag in list(device.tags.all())],
-            "distro_name": distro.name,
+            # Ultrahack: Remove distro name because that breaks templating
+            "distro_name": distro.name if traffic_vlan != WIFI_TRAFFIC_VLAN else None,
             "distro_phy_port": f"{distro_interface.name}.0",
             "mgmt_v4_addr": str(device.primary_ip4.address.ip) if device.primary_ip4 is not None else None,
             "mgmt_v6_addr": str(device.primary_ip6.address.ip) if device.primary_ip6 is not None else None,

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -113,7 +113,7 @@ class Netbox2Gondul(Script):
             self.log_warning(f'Network for VLAN <a href="{vlan.get_absolute_url()}">{vlan.name}</a> is missing IPv6 Prefix')
 
         try:
-            router = IPAddress.objects.get(address=gw4)
+            router = str(IPAddress.objects.get(address=gw4))
         except IPAddress.DoesNotExist:
             self.log_warning(f'Router not found for VLAN <a href="{vlan.get_absolute_url()}">{vlan.name}</a>')
             router = "r1.tele"

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -171,7 +171,7 @@ class Netbox2Gondul(Script):
             # "community": "", # Not implemented
             "tags": [tag.slug for tag in list(device.tags.all())],
             "distro_name": distro.name,
-            "distro_phy_port": distro_interface.name,  # TODO: always .0 ?
+            "distro_phy_port": f"{distro_interface.name}.0",
             "mgmt_v4_addr": str(device.primary_ip4.address.ip) if device.primary_ip4 is not None else None,
             "mgmt_v6_addr": str(device.primary_ip6.address.ip) if device.primary_ip6 is not None else None,
             "mgmt_vlan": mgmt_vlan_name,

--- a/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
+++ b/tools/netbox/scripts/netbox2gondul/netbox2gondul.py
@@ -159,8 +159,8 @@ class Netbox2Gondul(Script):
         traffic_vlan_name = None
         try:
             traffic_vlan = VLAN.objects.get(name=device.name)
-            traffic_prefix_v4 = Prefix.objects.get(vlan=traffic_vlan, family=4)
-            traffic_prefix_v6 = Prefix.objects.get(vlan=traffic_vlan, family=6)
+            traffic_prefix_v4 = Prefix.objects.get(vlan=traffic_vlan, prefix__family=4)
+            traffic_prefix_v6 = Prefix.objects.get(vlan=traffic_vlan, prefix__family=6)
 
             self.network_to_gondul(traffic_vlan, traffic_prefix_v4, traffic_prefix_v6)
         except VLAN.DoesNotExist:

--- a/tools/netbox/scripts/planning2netbox/planning2netbox.py
+++ b/tools/netbox/scripts/planning2netbox/planning2netbox.py
@@ -1,0 +1,299 @@
+from django.contrib.contenttypes.models import ContentType
+from django.utils.text import slugify
+
+from dcim.choices import DeviceStatusChoices, InterfaceModeChoices, InterfaceTypeChoices, SiteStatusChoices
+from dcim.models import Cable, CableTermination, Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
+from extras.models import Tag
+from extras.scripts import *
+from ipam.models import IPAddress, Prefix, VLAN, VLANGroup, Role
+from ipam.choices import PrefixStatusChoices, IPAddressFamilyChoices
+from netaddr import IPNetwork
+import random
+
+from utilities.exceptions import AbortScript
+
+
+# Used for getting existing types/objects from Netbox.
+DISTRIBUTION_SWITCH_DEVICE_ROLE = 'distribution-switch' # match the name or the slug
+ROUTER_DEVICE_ROLE = 'router'
+CORE_DEVICE_ROLE = 'core'
+ACCESS_SWITCH_DEVICE_ROLE = DeviceRole.objects.get(name='Access Switch')
+DEFAULT_SITE = Site.objects.get(slug='floor')
+DEFAULT_DEVICE_TYPE = DeviceType.objects.get(model='EX2200-48T')
+TAGS = [Tag.objects.get(name='dhcp-client')]
+FLOOR_MGMT_VLAN = VLAN.objects.get(name="edge-mgmt.floor.r1.tele")
+VLAN_GROUP_FLOOR = VLANGroup.objects.get(slug="floor")
+MULTIRATE_DEVICE_TYPE = DeviceType.objects.get(model="EX4300-48MP")
+CORE_DEVICE = Device.objects.get(name="r1.tele")
+CORE_INTERFACE_FLOOR = Interface.objects.get(device=CORE_DEVICE, description="d1.roof")
+
+
+# Copied from examples/tg19/netbox_tools/switchestxt2netbox.py
+def parse_switches_txt(switches_txt_lines, logger):
+    distros = {}
+    switches = {}
+    for switch in switches_txt_lines:
+        # example:
+        # e7-1 88.92.80.0/26 2a06:5844:e:71::/64 88.92.0.66/26 2a06:5841:d:2::66/64 1071 s2.floor
+        switch = switch.strip().split()
+        if len(switch) == 0:
+            # skip empty lines
+            continue
+        switches[switch[0]] = {
+            'sysname': switch[0],
+            'subnet4': switch[1],
+            'subnet6': switch[2],
+            'mgmt4': switch[3],
+            'mgmt6': switch[4],
+            'vlan_id': int(switch[5]),
+            'distro_name': switch[6],
+            'is_distro': False,
+            'device_type': DEFAULT_DEVICE_TYPE,
+            'lag_name': "ae0",
+        }
+    return switches
+
+def parse_patchlist_txt(patchlist_txt_lines, switches, logger):
+    for patchlist in patchlist_txt_lines:
+        columns = patchlist.split()
+        switch_name = columns[0]
+        if 'multirate' in patchlist:
+            switches[switch_name]['device_type'] = MULTIRATE_DEVICE_TYPE
+
+        uplinks = []
+        links = columns[2:]
+        for link in links:
+            # Skip columns with comments
+            if 'ge-' in link or 'mge-' in link:
+                uplinks.append(link)
+        switches[switch_name]['uplinks'] = uplinks
+
+
+class Planning2Netbox(Script):
+
+    class Meta:
+        name = "Planning to netbox"
+        description = "Import output from planning into netbox"
+        commit_default = False
+        field_order = ['site_name', 'switch_count', 'switch_model']
+        fieldsets = ""
+
+    switches_txt = TextVar(
+        description="Switch output from planning",
+    )
+
+    patchlist_txt = TextVar(
+        description="Patchlist output from planning",
+    )
+
+    def run(self, data, commit):
+
+        planning_tag, _created = Tag.objects.get_or_create(name="from-planning")
+
+        switches_txt_lines = data['switches_txt'].split('\n')
+        # clean "file" content
+        for i in range(0, len(switches_txt_lines)-1):
+            switches_txt_lines[i] = switches_txt_lines[i].strip()
+
+        patchlist_txt_lines = data['patchlist_txt'].split('\n')
+        # clean "file" content
+        for i in range(0, len(patchlist_txt_lines)-1):
+            patchlist_txt_lines[i] = patchlist_txt_lines[i].strip()
+
+        switches = parse_switches_txt(switches_txt_lines, self.log_debug)
+        patchlist = parse_patchlist_txt(patchlist_txt_lines, switches, self.log_debug)
+
+        self.log_info(f"Configuring {len(switches)} switches")
+
+        self.log_info("Importing switches")
+        for switch_name in switches:
+            data = switches[switch_name]
+            self.log_debug(f"Creating switch {switch_name} from {data}")
+            switch, created_switch = Device.objects.get_or_create(
+                name=switch_name,
+                device_type=data['device_type'],
+                device_role=ACCESS_SWITCH_DEVICE_ROLE,
+                site=DEFAULT_SITE,
+            )
+            if not created_switch:
+                self.log_info(f"Updating existing switch: {switch.name}")
+
+            distro = Device.objects.get(name=data['distro_name'])
+            mgmt_vlan = FLOOR_MGMT_VLAN
+            ae_interface = None
+            ae_interface, created_ae_interface = Interface.objects.get_or_create(
+                device=switch,
+                name=f"{data['lag_name']}",
+                description=distro.name,
+                type=InterfaceTypeChoices.TYPE_LAG,
+                mode=InterfaceModeChoices.MODE_TAGGED,
+            )
+            ae_interface.tagged_vlans.add(mgmt_vlan)
+            
+            # distro side
+            distro_ae_interface, created_distro_ae_interface = Interface.objects.get_or_create(
+                device=distro,
+                name=f"ae{data['vlan_id']}",  # TODO: can we get this from tagged vlans  on ae?
+                description=switch.name,
+                type=InterfaceTypeChoices.TYPE_LAG,
+                mode=InterfaceModeChoices.MODE_TAGGED,
+            )
+            if not created_distro_ae_interface:
+                self.log_info(f"Updated existing distro interface: {distro_ae_interface}")
+            distro_ae_interface.tagged_vlans.add(mgmt_vlan)
+
+            vlan_interface, _created_vlan_interface = Interface.objects.get_or_create(
+                device=switch,
+                name=f"vlan.{mgmt_vlan.vid}",
+                description=f"mgmt.{distro.name}",
+                type=InterfaceTypeChoices.TYPE_VIRTUAL,
+                mode=InterfaceModeChoices.MODE_TAGGED,
+            )
+
+            traffic_vlan, _created_traffic_vlan = VLAN.objects.get_or_create(
+                name=switch.name,
+                vid=data['vlan_id'],
+                group=VLAN_GROUP_FLOOR,
+            )
+
+            ae_interface.tagged_vlans.add(traffic_vlan)
+            ae_interface.tagged_vlans.add(traffic_vlan)
+
+            # patchlist
+            switch_uplinks = data['uplinks']
+            #self.log_debug(f"uplinks: {switch_uplinks}")
+
+            # from planning we always cable from port 44 and upwards
+            # except for multirate then we always use 47 and 48
+            # 'ge-0/0/44' or 'mge-0/0/47'
+            is_multirate = 'mge' in switch_uplinks[0]
+            uplink_port = 46 if is_multirate else 44
+            uplink_port_name = "mge-0/0/{}" if is_multirate else "ge-0/0/{}"
+
+            interface_type = ContentType.objects.get_for_model(Interface)
+            for distro_port in switch_uplinks:
+                distro_interface = Interface.objects.get(
+                    device=distro,
+                    name=distro_port,
+                )
+                distro_interface.lag = distro_ae_interface
+                distro_interface.save()
+
+                switch_uplink_interface = Interface.objects.get(
+                    device=switch,
+                    name=uplink_port_name.format(uplink_port),
+                )
+                switch_uplink_interface.lag = ae_interface
+                switch_uplink_interface.save()
+
+                # Delete A cable termination if it exists
+                try:
+                    CableTermination.objects.get(
+                        cable_end='A',
+                        termination_id=distro_interface.id,
+                        termination_type=interface_type,
+                    ).delete()
+                except CableTermination.DoesNotExist:
+                    pass
+
+                # Delete B cable termination if it exists
+                try:
+                    CableTermination.objects.get(
+                        cable_end='B',
+                        termination_id=switch_uplink_interface.id,
+                        termination_type=interface_type,
+                    ).delete()
+                except CableTermination.DoesNotExist:
+                    pass
+                
+                # Create cable now that we've cleaned up the cable mess.
+                cable = Cable.objects.create()
+                a = CableTermination.objects.create(
+                    cable=cable,
+                    cable_end='A',
+                    termination_id=distro_interface.id,
+                    termination_type=interface_type,
+                )
+                b = CableTermination.objects.create(
+                    cable_end='B',
+                    cable=cable,
+                    termination_id=switch_uplink_interface.id,
+                    termination_type=interface_type,
+                )
+                cable = Cable.objects.get(id=cable.id)
+                # https://github.com/netbox-community/netbox/discussions/10199
+                cable._terminations_modified = True
+                cable.save()
+                cable.tags.add(planning_tag)
+
+                #self.log_debug(f"Cabled switch port {b} to distro port {a}")
+
+                uplink_port += 1
+            
+
+            # Set mgmt ip
+            mgmt_addr_v4, _ = IPAddress.objects.get_or_create(
+                address=data['mgmt4'],
+            )
+            mgmt_addr_v6, _ = IPAddress.objects.get_or_create(
+                address=data['mgmt6'],
+            )
+            switch.primary_ip4 = mgmt_addr_v4
+            switch.primary_ip6 = mgmt_addr_v6
+            switch.save()
+
+            # Set prefix
+            prefix_v4, _ = Prefix.objects.get_or_create(
+                prefix=data['subnet4'],
+                vlan=traffic_vlan,
+            )
+            prefix_v6, _ = Prefix.objects.get_or_create(
+                prefix=data['subnet6'],
+                vlan=traffic_vlan,
+            )
+
+            core_subinterface, _ = Interface.objects.get_or_create(
+                device=CORE_DEVICE,
+                parent=CORE_INTERFACE_FLOOR,
+                name=f"{CORE_INTERFACE_FLOOR.name}.{traffic_vlan.vid}",
+                description=switch.name,
+                type=InterfaceTypeChoices.TYPE_VIRTUAL,
+                mode=InterfaceModeChoices.MODE_TAGGED,
+            )
+
+            # Set gw addrs
+
+            # We "manually create" an IP address from the defined
+            # network (instead of from the Prefix object)
+            # because the Prefix is not persisted in the database yet,
+            # and then some of the features of it doesn't work,
+            # e.g. prefix.get_first_available_ip().
+
+            uplink_addr_v4, _ = IPAddress.objects.get_or_create(
+                address=IPNetwork(data['subnet4'])[1],
+            )
+            uplink_addr_v6, _ = IPAddress.objects.get_or_create(
+                address=IPNetwork(data['subnet6'])[1],
+            )
+            core_subinterface.ip_addresses.add(uplink_addr_v4)
+            core_subinterface.ip_addresses.add(uplink_addr_v6)
+            core_subinterface.tagged_vlans.add(traffic_vlan)
+
+            # Add tag to everything we created so it's easy to identify in case we
+            # want to recreate
+            things_we_created = [
+                switch,
+                ae_interface,
+                distro_ae_interface,
+                vlan_interface,
+                traffic_vlan,
+                prefix_v4,
+                prefix_v6,
+                mgmt_addr_v4,
+                mgmt_addr_v6,
+                uplink_addr_v4,
+                uplink_addr_v6,
+                core_subinterface,
+            ]
+            for thing in things_we_created:
+                thing.tags.add(planning_tag)

--- a/tools/netbox/scripts/planning2netbox/planning2netbox.py
+++ b/tools/netbox/scripts/planning2netbox/planning2netbox.py
@@ -231,9 +231,13 @@ class Planning2Netbox(Script):
             # Set mgmt ip
             mgmt_addr_v4, _ = IPAddress.objects.get_or_create(
                 address=data['mgmt4'],
+                assigned_object_type=interface_type,
+                assigned_object_id=vlan_interface.id,
             )
             mgmt_addr_v6, _ = IPAddress.objects.get_or_create(
                 address=data['mgmt6'],
+                assigned_object_type=interface_type,
+                assigned_object_id=vlan_interface.id,
             )
             switch.primary_ip4 = mgmt_addr_v4
             switch.primary_ip6 = mgmt_addr_v6

--- a/tools/netbox/scripts/planning2netbox/planning2netbox.py
+++ b/tools/netbox/scripts/planning2netbox/planning2netbox.py
@@ -18,6 +18,11 @@ MULTIRATE_DEVICE_TYPE = DeviceType.objects.get(model="EX4300-48MP")
 CORE_DEVICE = Device.objects.get(name="r1.tele")
 CORE_INTERFACE_FLOOR = Interface.objects.get(device=CORE_DEVICE, description="d1.roof")
 
+TG = Tag.objects.get
+ACCESS_FLOOR_TAGS = [TG(slug="deltagere")]
+EX2200_TAGS = [TG(slug='3-uplinks')]
+MULTIRATE_TAGS = [TG(slug="multirate"), TG(slug="10g-uplink"), TG(slug="10g-copper"), TG(slug="2-uplinks")]
+
 # Copied from examples/tg19/netbox_tools/switchestxt2netbox.py
 def parse_switches_txt(switches_txt_lines):
     switches = {}
@@ -215,6 +220,13 @@ class Planning2Netbox(Script):
                 #self.log_debug(f"Cabled switch port {b} to distro port {a}")
 
                 uplink_port += 1
+
+            tags = ACCESS_FLOOR_TAGS.copy()
+            if is_multirate:
+                tags += MULTIRATE_TAGS.copy()
+            else:
+                tags += EX2200_TAGS.copy()
+            switch.tags.add(*tags)
 
             # Set mgmt ip
             mgmt_addr_v4, _ = IPAddress.objects.get_or_create(

--- a/tools/netbox/scripts/planning2netbox/planning2netbox.py
+++ b/tools/netbox/scripts/planning2netbox/planning2netbox.py
@@ -266,11 +266,15 @@ class Planning2Netbox(Script):
             # and then some of the features of it doesn't work,
             # e.g. prefix.get_first_available_ip().
 
+            subnet4 = IPNetwork(data['subnet4'])
+            uplink_addr_v4_raw = subnet4[1]
             uplink_addr_v4, _ = IPAddress.objects.get_or_create(
-                address=IPNetwork(data['subnet4'])[1],
+                address=f"{uplink_addr_v4_raw}/{subnet4.prefixlen}",
             )
+            subnet6 = IPNetwork(data['subnet6'])
+            uplink_addr_v6_raw = subnet6[1]
             uplink_addr_v6, _ = IPAddress.objects.get_or_create(
-                address=IPNetwork(data['subnet6'])[1],
+                address=f"{uplink_addr_v6_raw}/{subnet6.prefixlen}",
             )
             core_subinterface.ip_addresses.add(uplink_addr_v4)
             core_subinterface.ip_addresses.add(uplink_addr_v6)


### PR DESCRIPTION
An initial look at creating a switch "our way" in NetBox.

This PR is a work in progress and will contain comments and demos down the line 👍 

ToDo:

- [x] Feature-parity with [create-script.py](https://github.com/gathering/tgmanage/blob/main/examples/tg19/netbox_tools/create_switch.py)
- [x] Provide smart suggestions/dropdowns where feasible
- [x] Send data to Gondul ([will be done with NetBox webhooks](https://github.com/gathering/tgmanage/pull/106#issuecomment-1457129228))
- [x] Ensure cables are marked as 'connected' https://github.com/gathering/tgmanage/pull/106/files#r1127117814
- [x] Add docs (and maybe example implementation?) of how to [call this script using the NetBox API](https://demo.netbox.dev/static/docs/customization/custom-scripts/#via-the-api)
- [x] Clean up in options, remove options that can be inferred from others (e.g. "site" based on which "destination device" is picked)

ToDo in NetBox(es) where the scripts are to be deployed:
- [x] Create CustomField for VLAN ([implementation](https://github.com/gathering/tgmanage/commit/8c185ddbd59cb61835c615a5b7207a2b2fc99cd5))
- [x] Set up auto-sync of scripts from git

---

NetBox will filter to relevant objects, e.g. showing only devices on the "destination device", as well as filtering away already-connected interfaces.

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/5422571/222907738-a8aabf5f-cc85-4c5e-9c46-70f9415b39ca.png">